### PR TITLE
Code factor fixes

### DIFF
--- a/errorhandler.h
+++ b/errorhandler.h
@@ -73,7 +73,7 @@ struct FileError
     QFile *m_file = nullptr;
 
     FileError(ErrorPriority prioryty = ErrorPriority::Undefined, QString message = "", QFile *file = nullptr);
-    virtual void printMessage() override;
+    void printMessage() override;
 };
 
 

--- a/errorhandler.h
+++ b/errorhandler.h
@@ -55,7 +55,7 @@ struct InputError
     : Error
 {
     InputError(ErrorPriority prioryty = ErrorPriority::Undefined, QString message = "");
-    virtual void printMessage() override;
+    void printMessage() override;
 };
 
 

--- a/errorhandler.h
+++ b/errorhandler.h
@@ -63,7 +63,7 @@ struct MissingInputError
     : InputError
 {
     MissingInputError(ErrorPriority prioryty = ErrorPriority::Undefined, QString message = "");
-    virtual void printMessage() override;
+    void printMessage() override;
 };
 
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -50,7 +50,6 @@ class MainWindow : public QMainWindow
     Q_OBJECT
 
 private:
-
     Ui::MainWindow *m_ui = nullptr;
     QSqlDatabase *m_db = nullptr;
     QVector<unsigned int> m_selectedId = {};

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -63,7 +63,6 @@ private:
     QVector<QString> m_typeFilter = {};
 
 public:
-
     explicit MainWindow(QWidget* parent = 0);
     ~MainWindow();
 
@@ -71,7 +70,6 @@ public:
     void tableSelectionChanged();
 
 private slots:
-
     void on_actionA_propos_triggered();
     void on_actionQuitter_triggered();
     void on_AllConsellationsButton_clicked();

--- a/objectform.cpp
+++ b/objectform.cpp
@@ -710,7 +710,6 @@ void ObjectForm::on_SavePushButton_clicked()
             }
             else // modify an existing object
             {
-
                 m_db->open();
 
                 QSqlQuery query;


### PR DESCRIPTION
- Fix 'Do not leave a blank line after &quot;private:&quot;' issue in mainwindow.h resolved
- Fix 'Do not leave a blank line after &quot;public:&quot;' issue in mainwindow.h resolved
- Fix 'Redundant blank line at the start of a code block should be deleted.' issue in objectform.cpp resolved
- Fix '&quot;virtual&quot; is redundant since function is already declared as &quot;override&quot;' issue in errorhandler.h resolved
- Fix '&quot;virtual&quot; is redundant since function is already declared as &quot;override&quot;' issue in errorhandler.h resolved
- Fix '&quot;virtual&quot; is redundant since function is already declared as &quot;override&quot;' issue in errorhandler.h resolved